### PR TITLE
Increase bottom padding in MobileMenuContainer

### DIFF
--- a/src/Components/Header/Header.styles.ts
+++ b/src/Components/Header/Header.styles.ts
@@ -140,7 +140,7 @@ export const MobileMenuContainer = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 1rem;
-  padding: 1rem 2rem 5rem;
+  padding: 1rem 2rem 10rem;
   height: calc(100% - 5rem);
   width: 100%;
   overflow-y: auto;


### PR DESCRIPTION
Adjusted the bottom padding from 5rem to 10rem in the MobileMenuContainer styled component to provide more spacing at the bottom of the mobile menu.