### PR TITLE
Auto-detect active draft when LEAGUE_DRAFT_ID is unset

### DIFF
--- a/worker/src/cron.ts
+++ b/worker/src/cron.ts
@@ -214,18 +214,20 @@ async function resolveDraftId(env: Env, leagueId: string): Promise<string | null
       return active.draft_id;
     }
     const completedDrafts = drafts.filter((d) => d.status === 'complete');
+    const getDraftRecency = (draft: (typeof completedDrafts)[number]): number => {
+      const lastPicked =
+        typeof draft.last_picked === 'number' ? draft.last_picked : null;
+      const startTime =
+        typeof draft.start_time === 'number' ? draft.start_time : null;
+      const created = typeof draft.created === 'number' ? draft.created : null;
+      return lastPicked ?? startTime ?? created ?? 0;
+    };
     const recentComplete = completedDrafts.reduce<
       (typeof completedDrafts)[number] | null
     >((latest, current) => {
       if (!latest) return current;
-      const latestRecency =
-        (typeof latest.last_picked === 'number' ? latest.last_picked : 0) ||
-        (typeof latest.start_time === 'number' ? latest.start_time : 0) ||
-        (typeof latest.created === 'number' ? latest.created : 0);
-      const currentRecency =
-        (typeof current.last_picked === 'number' ? current.last_picked : 0) ||
-        (typeof current.start_time === 'number' ? current.start_time : 0) ||
-        (typeof current.created === 'number' ? current.created : 0);
+      const latestRecency = getDraftRecency(latest);
+      const currentRecency = getDraftRecency(current);
       return currentRecency > latestRecency ? current : latest;
     }, null);
     if (recentComplete) {

--- a/worker/src/cron.ts
+++ b/worker/src/cron.ts
@@ -213,7 +213,21 @@ async function resolveDraftId(env: Env, leagueId: string): Promise<string | null
       console.log(`Auto-detected active draft: ${active.draft_id}`);
       return active.draft_id;
     }
-    const recentComplete = drafts.find((d) => d.status === 'complete');
+    const completedDrafts = drafts.filter((d) => d.status === 'complete');
+    const recentComplete = completedDrafts.reduce<
+      (typeof completedDrafts)[number] | null
+    >((latest, current) => {
+      if (!latest) return current;
+      const latestRecency =
+        (typeof latest.last_picked === 'number' ? latest.last_picked : 0) ||
+        (typeof latest.start_time === 'number' ? latest.start_time : 0) ||
+        (typeof latest.created === 'number' ? latest.created : 0);
+      const currentRecency =
+        (typeof current.last_picked === 'number' ? current.last_picked : 0) ||
+        (typeof current.start_time === 'number' ? current.start_time : 0) ||
+        (typeof current.created === 'number' ? current.created : 0);
+      return currentRecency > latestRecency ? current : latest;
+    }, null);
     if (recentComplete) {
       console.log(
         `Auto-detected most recent completed draft: ${recentComplete.draft_id}`,

--- a/worker/src/cron.ts
+++ b/worker/src/cron.ts
@@ -21,6 +21,7 @@ import {
   getPlayerMap,
   fetchDraft,
   fetchDraftPicks,
+  fetchLeagueDrafts,
 } from './sleeper';
 import { generateTradeAnalysis } from './anthropic';
 import { generatePickAnalysis, generateTeamDraftGrade } from './draftAnalysis';
@@ -186,6 +187,48 @@ async function processWeekTrades(
 }
 
 /**
+ * Resolve which draft the cron should analyze.
+ *
+ * Priority:
+ *   1. env.LEAGUE_DRAFT_ID — explicit override, useful for targeting a specific
+ *      draft (e.g. a startup draft from a prior season).
+ *   2. The active draft for this league (status === 'drafting').
+ *   3. The most recent completed draft (so post-draft team grades can still be
+ *      generated even if the cron didn't catch the completion live).
+ *
+ * Returns null when nothing analyzable exists (e.g. only pre_draft entries, or
+ * the league has no drafts yet).
+ */
+async function resolveDraftId(env: Env, leagueId: string): Promise<string | null> {
+  if (env.LEAGUE_DRAFT_ID) {
+    return env.LEAGUE_DRAFT_ID;
+  }
+
+  try {
+    const drafts = await fetchLeagueDrafts(leagueId);
+    // Sleeper returns drafts in reverse chronological order. Skip pre_draft —
+    // there are no picks to analyze yet.
+    const active = drafts.find((d) => d.status === 'drafting');
+    if (active) {
+      console.log(`Auto-detected active draft: ${active.draft_id}`);
+      return active.draft_id;
+    }
+    const recentComplete = drafts.find((d) => d.status === 'complete');
+    if (recentComplete) {
+      console.log(
+        `Auto-detected most recent completed draft: ${recentComplete.draft_id}`,
+      );
+      return recentComplete.draft_id;
+    }
+    console.log('No active or completed draft found for this league');
+    return null;
+  } catch (err) {
+    console.error('Error auto-detecting league draft:', err);
+    return null;
+  }
+}
+
+/**
  * Handle scheduled cron trigger
  */
 export async function handleScheduled(env: Env): Promise<void> {
@@ -268,8 +311,9 @@ export async function handleScheduled(env: Env): Promise<void> {
 
   console.log(`Cron job completed. Processed ${totalProcessed} new trade(s)`);
 
-  // Draft analysis — only runs when LEAGUE_DRAFT_ID is configured
-  const draftId = env.LEAGUE_DRAFT_ID;
+  // Draft analysis — auto-detects the active draft from the league when
+  // LEAGUE_DRAFT_ID is unset. Manual override via env var still wins.
+  const draftId = await resolveDraftId(env, leagueId);
   if (draftId) {
     try {
       await processDraftAnalysis(env, draftId, leagueId, rosters, users, allPlayers);

--- a/worker/src/sleeper.ts
+++ b/worker/src/sleeper.ts
@@ -198,3 +198,16 @@ export async function fetchDraftPicks(draftId: string): Promise<SleeperDraftPick
   }
   return response.json();
 }
+
+/**
+ * Fetch all drafts associated with a league.
+ * Sleeper returns drafts in reverse chronological order (newest first).
+ * Used by the cron to auto-detect the active draft when LEAGUE_DRAFT_ID is unset.
+ */
+export async function fetchLeagueDrafts(leagueId: string): Promise<SleeperDraft[]> {
+  const response = await fetch(`${SLEEPER_API_BASE}/league/${leagueId}/drafts`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch league drafts: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -22,5 +22,7 @@ crons = ["*/1 * * * *"]
 SLEEPER_LEAGUE_ID = "1326434695138787328"
 TRADE_ANALYSIS_VERSION = "v2"
 DRAFT_ANALYSIS_VERSION = "v1"
-# Set LEAGUE_DRAFT_ID to the active draft's ID to enable draft analysis
+# LEAGUE_DRAFT_ID is optional. When unset, the cron auto-detects the active
+# (or most recent completed) draft via Sleeper's /league/{id}/drafts endpoint.
+# Set it explicitly only to override auto-detection for a specific draft.
 # LEAGUE_DRAFT_ID = ""


### PR DESCRIPTION
## Why

During the live 5/7 rookie draft, no per-pick analyses were appearing on the site. Root cause: `worker/wrangler.toml` had `LEAGUE_DRAFT_ID` commented out, and `cron.ts` gated the entire draft pipeline on `if (env.LEAGUE_DRAFT_ID)`. Trades kept being analyzed; the draft block was silently skipped every tick.

## What

Auto-detect the draft from Sleeper's `/league/{league_id}/drafts` endpoint when `LEAGUE_DRAFT_ID` isn't set. Resolution order:

1. **`env.LEAGUE_DRAFT_ID`** — explicit override (kept for cases like analyzing a specific historical draft).
2. **Active draft** (`status === 'drafting'`) — what we want during draft week.
3. **Most recent completed draft** (`status === 'complete'`) — so post-draft team grades can still generate retroactively if the cron didn't catch the live completion.

If none match, log and skip — same behavior as before, just now reachable instead of being the silent default.

## Changes

- **`worker/src/sleeper.ts`** — new `fetchLeagueDrafts(leagueId)` function. Mirrors the existing `fetchDraft` / `fetchDraftPicks` pattern.
- **`worker/src/cron.ts`** — new `resolveDraftId(env, leagueId)` helper called from `handleScheduled`. Replaces the inline `const draftId = env.LEAGUE_DRAFT_ID` lookup. No changes to `processDraftAnalysis` itself.
- **`worker/wrangler.toml`** — comment updated to describe the env var as an override rather than a requirement. The line itself stays commented out.

## Testing notes

- One extra Sleeper API call per cron tick (when the env var is unset). Sleeper's `/league/{id}/drafts` is unauthenticated and fast; the additional load is negligible.
- The existing `MAX_PICKS_PER_TICK = 3` cap still applies, so this fix doesn't change pacing — once deployed, expect picks to fill in 3 at a time per minute. With ~11 picks already made before the fix, that's ~4 ticks to catch up.
- Manually verified the resolution order by reading `cron.ts` end-to-end. No types changed; `SleeperDraft[]` was already exported from `types.ts`.

## Risk

Low. Only affects the draft path. If `fetchLeagueDrafts` errors, the catch block returns `null` and the cron falls back to its prior no-op behavior — no regression to trade analysis.

## Followups (not in this PR)

- The frontend has the same auto-detect logic via its own `fetchDrafts` call. Worth checking whether the worker and frontend can share a definition of "active draft" to avoid drift.
- Issue #66 (draft board column headers + live polling) is still open and unrelated to this fix.