### PR TITLE
Wire FantasyCalc dynasty rookie values into draft analysis

### DIFF
--- a/worker/src/cron.ts
+++ b/worker/src/cron.ts
@@ -399,6 +399,8 @@ async function processDraftAnalysis(
         playerMap,
         priorPicks,
         rookieValues,
+        draft.settings.rounds,
+        draft.settings.teams,
         env.ANTHROPIC_API_KEY,
       );
 

--- a/worker/src/cron.ts
+++ b/worker/src/cron.ts
@@ -25,6 +25,7 @@ import {
 } from './sleeper';
 import { generateTradeAnalysis } from './anthropic';
 import { generatePickAnalysis, generateTeamDraftGrade } from './draftAnalysis';
+import { getRookieValueMap } from './rookieValues';
 import { analysisExists, saveAnalysis, pickAnalysisExists, savePickAnalysis, teamDraftGradeExists, saveTeamDraftGrade } from './db';
 
 /**
@@ -356,9 +357,13 @@ async function processDraftAnalysis(
 ): Promise<void> {
   console.log(`Processing draft analysis for draft ${draftId}...`);
 
-  const [draft, picks] = await Promise.all([
+  const [draft, picks, rookieValues] = await Promise.all([
     fetchDraft(draftId),
     fetchDraftPicks(draftId),
+    // FantasyCalc dynasty values, cached in KV with 24h TTL. Returns an empty
+    // map on failure — the analysis functions will still run, they just won't
+    // have ADP context for that tick.
+    getRookieValueMap(env.PLAYERS_KV),
   ]);
 
   if (picks.length === 0) {
@@ -393,6 +398,7 @@ async function processDraftAnalysis(
         users,
         playerMap,
         priorPicks,
+        rookieValues,
         env.ANTHROPIC_API_KEY,
       );
 
@@ -450,6 +456,7 @@ async function processDraftAnalysis(
         rosters,
         users,
         playerMap,
+        rookieValues,
         env.ANTHROPIC_API_KEY,
       );
 

--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -133,12 +133,15 @@ function buildPickContext(
   if (fcValue) {
     computedDelta = pick.pick_no - fcValue.overallRank;
     const deltaSign = computedDelta > 0 ? '+' : '';
+    const posRankStr = fcValue.positionRank !== undefined
+      ? `, #${fcValue.positionRank} at ${position}`
+      : '';
     valueLine =
-      `Dynasty rank (FantasyCalc): #${fcValue.overallRank} overall, #${fcValue.positionRank} at ${position} (value ${fcValue.value})\n` +
+      `Dynasty rank (FantasyCalc): #${fcValue.overallRank} overall${posRankStr} (value ${fcValue.value})\n` +
       `Slot vs rank: picked at #${pick.pick_no}, ranked #${fcValue.overallRank} → delta ${deltaSign}${computedDelta} (${deltaLabel(computedDelta)})\n`;
   } else {
     valueLine =
-      `Dynasty rank: not in FantasyCalc database (likely a deeper prospect or late riser). Do not speculate about value; comment on player profile and team fit instead.\n`;
+      `Dynasty rank: unavailable (player not found in FantasyCalc or data failed to load). Do not speculate about value; comment on player profile and team fit instead.\n`;
   }
 
   let context = `Pick #${pick.pick_no} (Round ${pick.round})\n`;
@@ -168,6 +171,8 @@ export async function generatePickAnalysis(
   playerMap: Record<string, PlayerInfo>,
   priorPicks: SleeperDraftPick[],
   rookieValues: RookieValueMap,
+  draftRounds: number,
+  draftTeams: number,
   apiKey: string,
 ): Promise<DraftPickAnalysis> {
   const anthropic = new Anthropic({ apiKey });
@@ -184,7 +189,7 @@ export async function generatePickAnalysis(
   const prompt = `You are Mike and Jim, two fantasy football analysts giving a quick take on a dynasty rookie draft pick.
 
 Context:
-- This is a 4-round, 40-pick dynasty rookie draft. Every player is an incoming NFL rookie.
+- This is a ${draftRounds}-round, ${draftRounds * draftTeams}-pick dynasty rookie draft. Every player is an incoming NFL rookie.
 - The pick details below include the player's dynasty rank from FantasyCalc, which represents the consensus dynasty community valuation. Treat this as the authoritative source for whether the pick was made at a fair slot.
 - "Slot vs rank" tells you exactly whether the pick was good value, fair, or a reach. Use that as your starting point — do not invent your own ADP intuitions.
 - If a player has no FantasyCalc rank, do NOT speculate about value. Focus only on player profile and team fit.
@@ -327,7 +332,7 @@ function buildTeamGradeContext(
       totalSlotDelta += delta;
       picksWithValue++;
     } else {
-      valueSegment = ' | Dynasty rank: not in FantasyCalc';
+      valueSegment = ' | Dynasty rank: unavailable';
     }
 
     context += `  Pick #${pick.pick_no} (Rd ${pick.round}): ${playerName} — ${position}, ${nflTeam}${age}${valueSegment}\n`;

--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -12,6 +12,7 @@ import type {
   DraftPickAnalysis,
   TeamDraftGrade,
 } from './types';
+import type { RookieValueMap } from './rookieValues';
 
 // ─── Per-pick analysis ────────────────────────────────────────────────────────
 
@@ -62,14 +63,35 @@ function computeRosterShape(
   return shape;
 }
 
+/**
+ * Bucket the slot-vs-rank delta into a qualitative label for the prompt.
+ * Positive delta = picked LATER than expected = good value for drafter.
+ * Negative delta = picked EARLIER than expected = reach.
+ */
+function deltaLabel(delta: number): string {
+  if (delta >= 8) return 'major value — fell well below consensus';
+  if (delta >= 4) return 'good value — fell below consensus';
+  if (delta >= 2) return 'slight value';
+  if (delta >= -1) return 'roughly at consensus';
+  if (delta >= -3) return 'slight reach';
+  if (delta >= -7) return 'reach — taken meaningfully early';
+  return 'major reach — taken well above consensus';
+}
+
+interface PickContextResult {
+  context: string;
+  /** Slot - overallRank. null when no FantasyCalc data is available. */
+  computedDelta: number | null;
+}
+
 function buildPickContext(
   pick: SleeperDraftPick,
-  draftId: string,
   rosters: SleeperRoster[],
   users: SleeperUser[],
   playerMap: Record<string, PlayerInfo>,
   priorPicks: SleeperDraftPick[],
-): string {
+  rookieValues: RookieValueMap,
+): PickContextResult {
   const meta = pick.metadata ?? {};
   const playerName = meta.first_name && meta.last_name
     ? `${meta.first_name} ${meta.last_name}`
@@ -79,21 +101,11 @@ function buildPickContext(
 
   const playerInfo = playerMap[pick.player_id];
   const age = playerInfo?.age !== undefined ? `Age ${playerInfo.age}` : null;
-  // years_exp === 0 in Sleeper indicates a rookie. Surface this affirmatively
-  // rather than as "0 yrs exp" so the model parses it correctly.
   const rookieFlag = playerInfo?.years_exp === 0
     ? 'Rookie (no NFL snaps yet)'
     : playerInfo?.years_exp !== undefined
     ? `${playerInfo.years_exp} NFL years`
     : null;
-
-  // NOTE: We intentionally do NOT include Sleeper's search_rank here. It is a
-  // global redraft-style ranking that places unproven rookies in the 200+ range
-  // because they're not useful in same-season redraft formats. Comparing
-  // search_rank against rookie-draft slot numbers (1–40) produced bogus "reach"
-  // labels for every pick. Until proper dynasty rookie ADP is wired in (see
-  // FantasyCalc integration issue), it's better to omit ADP context entirely
-  // and let the model lean on NFL Draft capital, landing spot, and fit.
 
   const teamName = getTeamName(pick.roster_id, rosters, users);
   const roster = rosters.find((r) => r.roster_id === pick.roster_id);
@@ -106,26 +118,43 @@ function buildPickContext(
     .map(([pos, cnt]) => `${pos}: ${cnt}`)
     .join(', ');
 
-  // Prior picks in this draft for context (has this team been heavy at a position?)
   const teamPriorPicks = priorPicks.filter((p) => p.roster_id === pick.roster_id);
   const teamPriorPositions = teamPriorPicks
     .map((p) => p.metadata?.position ?? '?')
     .join(', ');
 
-  let context = `Draft ID: ${draftId}\n`;
-  context += `Pick #${pick.pick_no} (Round ${pick.round})\n`;
+  // FantasyCalc dynasty value (the authoritative ADP signal for rookies).
+  // The dynasty value already implicitly bakes in NFL Draft capital, landing
+  // spot, and athletic profile — exactly the signals the model is missing
+  // due to its training cutoff predating the actual NFL Draft.
+  const fcValue = rookieValues.players[pick.player_id];
+  let computedDelta: number | null = null;
+  let valueLine = '';
+  if (fcValue) {
+    computedDelta = pick.pick_no - fcValue.overallRank;
+    const deltaSign = computedDelta > 0 ? '+' : '';
+    valueLine =
+      `Dynasty rank (FantasyCalc): #${fcValue.overallRank} overall, #${fcValue.positionRank} at ${position} (value ${fcValue.value})\n` +
+      `Slot vs rank: picked at #${pick.pick_no}, ranked #${fcValue.overallRank} → delta ${deltaSign}${computedDelta} (${deltaLabel(computedDelta)})\n`;
+  } else {
+    valueLine =
+      `Dynasty rank: not in FantasyCalc database (likely a deeper prospect or late riser). Do not speculate about value; comment on player profile and team fit instead.\n`;
+  }
+
+  let context = `Pick #${pick.pick_no} (Round ${pick.round})\n`;
   context += `Player: ${playerName} | Position: ${position} | NFL Team: ${nflTeam}\n`;
   if (age || rookieFlag) {
     context += `Profile: ${[age, rookieFlag].filter(Boolean).join(', ')}\n`;
   }
-  context += `Drafted By: ${teamName} (Roster ID: ${pick.roster_id})\n`;
+  context += valueLine;
+  context += `Drafted By: ${teamName}\n`;
   if (shapeParts) {
-    context += `${teamName}'s current roster: ${shapeParts}\n`;
+    context += `${teamName}'s current roster shape: ${shapeParts}\n`;
   }
   if (teamPriorPicks.length > 0) {
     context += `${teamName}'s prior picks in this draft: ${teamPriorPositions}\n`;
   }
-  return context;
+  return { context, computedDelta };
 }
 
 /**
@@ -138,40 +167,47 @@ export async function generatePickAnalysis(
   users: SleeperUser[],
   playerMap: Record<string, PlayerInfo>,
   priorPicks: SleeperDraftPick[],
+  rookieValues: RookieValueMap,
   apiKey: string,
 ): Promise<DraftPickAnalysis> {
   const anthropic = new Anthropic({ apiKey });
 
-  const context = buildPickContext(pick, draftId, rosters, users, playerMap, priorPicks);
+  const { context, computedDelta } = buildPickContext(
+    pick,
+    rosters,
+    users,
+    playerMap,
+    priorPicks,
+    rookieValues,
+  );
 
-  const prompt = `You are analyzing a pick in a DYNASTY ROOKIE DRAFT. Provide a brief, entertaining hot take as a short conversation between two analysts, Mike and Jim.
+  const prompt = `You are Mike and Jim, two fantasy football analysts giving a quick take on a dynasty rookie draft pick.
 
-CRITICAL CONTEXT — read carefully before judging this pick:
-- Every player taken in this draft is an incoming NFL rookie who has NOT played a single professional snap.
-- Traditional/redraft ADP does NOT apply here. Rookies always rank low in redraft formats because they're unproven; that is irrelevant in a dynasty rookie draft.
-- Evaluate the pick using:
-  • NFL Draft capital (what round/team the player was selected by in the actual NFL Draft)
-  • Landing spot and depth chart opportunity
-  • Age and athletic profile
-  • Positional scarcity in dynasty (elite WRs are scarcer than RBs; QBs gain value in superflex)
-  • Fit with the drafting team's existing roster
-- Do NOT call this pick a "reach" unless the player would clearly go multiple rounds later in any reasonable dynasty rookie ranking. When uncertain, treat it as fair value.
+Context:
+- This is a 4-round, 40-pick dynasty rookie draft. Every player is an incoming NFL rookie.
+- The pick details below include the player's dynasty rank from FantasyCalc, which represents the consensus dynasty community valuation. Treat this as the authoritative source for whether the pick was made at a fair slot.
+- "Slot vs rank" tells you exactly whether the pick was good value, fair, or a reach. Use that as your starting point — do not invent your own ADP intuitions.
+- If a player has no FantasyCalc rank, do NOT speculate about value. Focus only on player profile and team fit.
 
-Pick Details:
+What to discuss:
+- Whether the pick was good value, fair, or a reach (per the delta)
+- Player profile and fit with the drafting team's roster shape
+- Positional dynasty appeal (elite WRs scarce, RBs age fast, QBs matter more in superflex)
+- Snark and entertainment
+
+Pick details:
 ${context}
 
 Instructions:
-1. Give this pick a letter grade (A+, A, A-, B+, B, B-, C+, C, C-, D+, D, F)
-2. Set value_vs_adp as a small integer string. Default to "0" (fair value). Use a small positive number (1–3) only if you're confident the player is widely viewed as a clearly better pick than this slot, and a small negative (-1 to -3) only if clearly a reach. Do NOT use large magnitudes — this is a 4-round, 40-pick draft.
-3. Write 2-3 short, punchy exchanges between Mike and Jim
-4. Write a one-sentence hot_take
-
-Keep it snarky, quick, and dynasty-rookie-focused.`;
+1. Letter grade (A+ through F) reflecting both player quality and slot value.
+2. value_vs_adp: short integer-string. Use the slot-vs-rank delta directly when available, "0" when no FantasyCalc data.
+3. 2–3 short, punchy Mike & Jim exchanges.
+4. One-sentence hot_take.`;
 
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
     max_tokens: 800,
-    system: 'You are a fantasy football analyst providing quick, snarky takes on dynasty rookie draft picks. You understand that rookies have no NFL track record yet and that traditional redraft ADP is meaningless in a rookie-only dynasty draft.',
+    system: 'You are Mike and Jim, dynasty fantasy football analysts. You evaluate rookie draft picks using FantasyCalc dynasty rankings as the authoritative consensus, supplemented by player profile and roster fit.',
     tools: [
       {
         name: 'submit_pick_analysis',
@@ -189,8 +225,15 @@ Keep it snarky, quick, and dynasty-rookie-focused.`;
   }
 
   const analysis = toolUseBlock.input as Omit<DraftPickAnalysis, 'pick_id' | 'draft_id' | 'pick_no'>;
+
+  // Always overwrite value_vs_adp with the computed delta (or "0" when we
+  // have no FantasyCalc data). The model's emitted value is unreliable; the
+  // delta is deterministic and matches the prompt context exactly.
+  const sanitizedValue = computedDelta !== null ? String(computedDelta) : '0';
+
   return {
     ...analysis,
+    value_vs_adp: sanitizedValue,
     pick_id: `${draftId}:${pick.pick_no}`,
     draft_id: draftId,
     pick_no: pick.pick_no,
@@ -241,6 +284,7 @@ function buildTeamGradeContext(
   rosters: SleeperRoster[],
   users: SleeperUser[],
   playerMap: Record<string, PlayerInfo>,
+  rookieValues: RookieValueMap,
 ): string {
   const teamName = getTeamName(rosterId, rosters, users);
   const roster = rosters.find((r) => r.roster_id === rosterId);
@@ -253,11 +297,15 @@ function buildTeamGradeContext(
     .map(([pos, cnt]) => `${pos}: ${cnt}`)
     .join(', ');
 
-  let context = `Team: ${teamName} (Roster ID: ${rosterId})\n`;
+  let totalValue = 0;
+  let totalSlotDelta = 0;
+  let picksWithValue = 0;
+
+  let context = `Team: ${teamName}\n`;
   if (shapeParts) {
-    context += `Existing roster: ${shapeParts}\n`;
+    context += `Existing roster shape: ${shapeParts}\n`;
   }
-  context += `\nDraft picks (all rookies):\n`;
+  context += `\nDraft picks (all incoming NFL rookies):\n`;
 
   for (const pick of teamPicks) {
     const meta = pick.metadata ?? {};
@@ -268,8 +316,27 @@ function buildTeamGradeContext(
     const nflTeam = meta.team ?? 'FA';
     const playerInfo = playerMap[pick.player_id];
     const age = playerInfo?.age !== undefined ? `, age ${playerInfo.age}` : '';
-    // Intentionally omitting Sleeper search_rank — see note in buildPickContext.
-    context += `  Pick #${pick.pick_no} (Rd ${pick.round}): ${playerName} — ${position}, ${nflTeam}${age}\n`;
+
+    const fcValue = rookieValues.players[pick.player_id];
+    let valueSegment = '';
+    if (fcValue) {
+      const delta = pick.pick_no - fcValue.overallRank;
+      const deltaSign = delta > 0 ? '+' : '';
+      valueSegment = ` | Dynasty #${fcValue.overallRank} overall (delta ${deltaSign}${delta}: ${deltaLabel(delta)})`;
+      totalValue += fcValue.value;
+      totalSlotDelta += delta;
+      picksWithValue++;
+    } else {
+      valueSegment = ' | Dynasty rank: not in FantasyCalc';
+    }
+
+    context += `  Pick #${pick.pick_no} (Rd ${pick.round}): ${playerName} — ${position}, ${nflTeam}${age}${valueSegment}\n`;
+  }
+
+  if (picksWithValue > 0) {
+    const avgDelta = totalSlotDelta / picksWithValue;
+    const avgSign = avgDelta > 0 ? '+' : '';
+    context += `\nClass totals (FantasyCalc-rated picks only): total value ${totalValue}, average slot-vs-rank delta ${avgSign}${avgDelta.toFixed(1)}\n`;
   }
 
   return context;
@@ -285,31 +352,45 @@ export async function generateTeamDraftGrade(
   rosters: SleeperRoster[],
   users: SleeperUser[],
   playerMap: Record<string, PlayerInfo>,
+  rookieValues: RookieValueMap,
   apiKey: string,
 ): Promise<TeamDraftGrade> {
   const anthropic = new Anthropic({ apiKey });
 
-  const context = buildTeamGradeContext(rosterId, teamPicks, rosters, users, playerMap);
+  const context = buildTeamGradeContext(
+    rosterId,
+    teamPicks,
+    rosters,
+    users,
+    playerMap,
+    rookieValues,
+  );
 
-  const prompt = `You are grading a DYNASTY ROOKIE DRAFT class for one team. Give an overall draft grade and a short Mike & Jim conversation.
+  const prompt = `You are Mike and Jim grading one team's dynasty rookie draft class.
 
-CRITICAL CONTEXT:
-- Every pick below is an incoming NFL rookie. None has played a pro snap.
-- Do NOT apply traditional/redraft ADP. Rookies always rank low in redraft; that is irrelevant in a rookie-only dynasty draft.
-- Grade based on: NFL Draft capital, landing spot, age/athletic profile, positional scarcity in dynasty, and how the new picks fit with the team's existing roster shape.
+Context:
+- This is a dynasty rookie draft. All picks below are incoming NFL rookies.
+- Each pick includes the player's FantasyCalc dynasty rank — the consensus dynasty community valuation. Use this as the authoritative source for whether picks were made at fair slots.
+- "Class totals" tells you the team's average slot-vs-rank delta. Positive average = team consistently got value. Negative average = team consistently reached.
+
+Grade based on:
+- Total dynasty value accumulated (sum of FantasyCalc values)
+- How well the rookies fill positional needs in the existing roster
+- Whether the team got value at each slot or reached
+- Positional dynasty appeal of the class (WRs and TEs age slowly; RBs are volatile)
 
 ${context}
 
 Instructions:
-1. Give an overall letter grade for this team's rookie draft class
-2. Call out the best pick and worst pick (by pick_no) with a one-sentence reason each. If the team only had great picks, pick the weakest of the strong; if all picks were poor, pick the least bad.
-3. Write a 2-3 sentence summary of the draft class
-4. Write 2-3 exchanges between Mike and Jim about this draft`;
+1. Letter grade for the rookie class.
+2. Best pick + worst pick (by pick_no) with one-sentence reason each (cite the dynasty rank when relevant).
+3. 2–3 sentence summary of the class.
+4. 2–3 exchanges between Mike and Jim about the team's strategy and execution.`;
 
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
     max_tokens: 1000,
-    system: 'You are a fantasy football analyst grading dynasty rookie draft classes. You understand that rookies have no NFL track record yet and that redraft ADP does not apply.',
+    system: 'You are Mike and Jim, dynasty fantasy football analysts. You grade rookie draft classes using FantasyCalc dynasty rankings as the authoritative consensus, total class value, slot-vs-rank deltas, and roster fit.',
     tools: [
       {
         name: 'submit_team_grade',

--- a/worker/src/rookieValues.ts
+++ b/worker/src/rookieValues.ts
@@ -21,8 +21,8 @@ export interface RookieValue {
   value: number;
   /** Overall rank across all dynasty assets (lower = more valuable) */
   overallRank: number;
-  /** Rank within the player's position */
-  positionRank: number;
+  /** Rank within the player's position — omitted when not present in API response */
+  positionRank?: number;
 }
 
 export interface RookieValueMap {
@@ -91,7 +91,7 @@ export async function getRookieValueMap(kv: KVNamespace): Promise<RookieValueMap
       const v: RookieValue = {
         value: entry.value,
         overallRank: entry.overallRank,
-        positionRank: entry.positionRank ?? 0,
+        ...(entry.positionRank !== undefined && { positionRank: entry.positionRank }),
       };
 
       if (player.position === 'PICK') {

--- a/worker/src/rookieValues.ts
+++ b/worker/src/rookieValues.ts
@@ -1,0 +1,124 @@
+/**
+ * Dynasty Rookie Values from FantasyCalc
+ *
+ * Fetches dynasty values for players (and rookie picks) from FantasyCalc's
+ * public API. Sleeper player IDs are native to the response, so no fuzzy
+ * matching is required. Values are cached in KV with a 24-hour TTL.
+ *
+ * League format params are currently hardcoded for this league (10-team,
+ * 1QB, full PPR). When the league config evolves, these should be sourced
+ * from fetchLeague() — see issue #59 for the full integration spec.
+ */
+
+const FANTASYCALC_URL =
+  'https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=1&numTeams=10&ppr=1';
+
+const KV_KEY = 'fantasycalc_dynasty_v1';
+const TTL_SECONDS = 86400; // 24 hours — values shift slowly
+
+export interface RookieValue {
+  /** FantasyCalc dynasty value (roughly 0–10000 scale) */
+  value: number;
+  /** Overall rank across all dynasty assets (lower = more valuable) */
+  overallRank: number;
+  /** Rank within the player's position */
+  positionRank: number;
+}
+
+export interface RookieValueMap {
+  /** Keyed by Sleeper player ID */
+  players: Record<string, RookieValue>;
+  /** Keyed by `${season}:${round}` for rookie picks (e.g. "2026:1") */
+  picks: Record<string, RookieValue>;
+}
+
+interface FantasyCalcEntry {
+  player?: {
+    sleeperId?: string | null;
+    name?: string;
+    position?: string;
+  };
+  value?: number;
+  overallRank?: number;
+  positionRank?: number;
+}
+
+const EMPTY_MAP: RookieValueMap = { players: {}, picks: {} };
+
+/**
+ * Parse a FantasyCalc pick name into {season, round}.
+ * Examples: "2026 1st" → {2026, 1}, "2027 Mid 2nd" → {2027, 2}.
+ * Returns null if the format isn't recognized.
+ */
+function parsePickName(name: string): { season: string; round: number } | null {
+  const match = name.match(/^(\d{4}).*?(\d)(?:st|nd|rd|th)/i);
+  if (!match) return null;
+  const round = parseInt(match[2], 10);
+  if (!Number.isFinite(round)) return null;
+  return { season: match[1], round };
+}
+
+/**
+ * Fetch (or return cached) the dynasty value map from FantasyCalc.
+ * Returns an empty map on any error so callers can degrade gracefully.
+ */
+export async function getRookieValueMap(kv: KVNamespace): Promise<RookieValueMap> {
+  try {
+    const cached = await kv.get(KV_KEY, 'json');
+    if (cached) {
+      return cached as RookieValueMap;
+    }
+  } catch (err) {
+    console.error('Failed to read rookie values from KV:', err);
+  }
+
+  try {
+    const response = await fetch(FANTASYCALC_URL);
+    if (!response.ok) {
+      console.error(
+        `FantasyCalc fetch failed: ${response.status} ${response.statusText}`,
+      );
+      return EMPTY_MAP;
+    }
+    const entries = (await response.json()) as FantasyCalcEntry[];
+    const map: RookieValueMap = { players: {}, picks: {} };
+
+    for (const entry of entries) {
+      const player = entry.player;
+      if (!player) continue;
+      if (entry.value === undefined || entry.overallRank === undefined) continue;
+
+      const v: RookieValue = {
+        value: entry.value,
+        overallRank: entry.overallRank,
+        positionRank: entry.positionRank ?? 0,
+      };
+
+      if (player.position === 'PICK') {
+        const parsed = player.name ? parsePickName(player.name) : null;
+        if (parsed) {
+          map.picks[`${parsed.season}:${parsed.round}`] = v;
+        }
+        continue;
+      }
+
+      if (player.sleeperId) {
+        map.players[player.sleeperId] = v;
+      }
+    }
+
+    try {
+      await kv.put(KV_KEY, JSON.stringify(map), { expirationTtl: TTL_SECONDS });
+    } catch (err) {
+      console.error('Failed to write rookie values to KV:', err);
+    }
+
+    console.log(
+      `FantasyCalc loaded: ${Object.keys(map.players).length} players, ${Object.keys(map.picks).length} picks`,
+    );
+    return map;
+  } catch (err) {
+    console.error('Failed to fetch FantasyCalc values:', err);
+    return EMPTY_MAP;
+  }
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -21,7 +21,7 @@ crons = ["*/1 * * * *"]
 [vars]
 SLEEPER_LEAGUE_ID = "1326434695138787328"
 TRADE_ANALYSIS_VERSION = "v2"
-DRAFT_ANALYSIS_VERSION = "v2"
+DRAFT_ANALYSIS_VERSION = "v3"
 # LEAGUE_DRAFT_ID is optional. When unset, the cron auto-detects the active
 # (or most recent completed) draft via Sleeper's /league/{id}/drafts endpoint.
 # Set it explicitly only to override auto-detection for a specific draft.


### PR DESCRIPTION
## Why

Per the live-draft thread: the model has been calling everything a reach because it's missing two things — current dynasty rookie ADP, and (because of its Jan 2026 training cutoff) the actual 2026 NFL Draft results. PR #70 papered over the symptom by banning the word; this PR fixes the cause by giving the model real consensus data.

## What

Wires FantasyCalc's public dynasty-values API into draft analysis. Their endpoint at `api.fantasycalc.com/values/current` returns dynasty values keyed by **native Sleeper player IDs** (no fuzzy matching), and those values implicitly bake in NFL Draft capital, landing spot, and athletic profile — which is exactly what the model couldn't produce on its own.

### New: `worker/src/rookieValues.ts`
- `getRookieValueMap(kv)` fetches FantasyCalc, caches in KV with 24h TTL
- Returns `{ players: Record<sleeperId, RookieValue>, picks: Record<season:round, RookieValue> }`
- Each `RookieValue` carries `value`, `overallRank`, `positionRank`
- League format hardcoded (10-team, 1QB, full PPR) — sourcing this from `fetchLeague()` is tracked in #59
- Returns empty map on any failure so the cron tick degrades cleanly

### Updated: `worker/src/draftAnalysis.ts`
- Per-pick context now includes the player's dynasty rank, position rank, value, and a `pick_no - overallRank` delta with a qualitative bucket (major value / good value / slight value / consensus / slight reach / reach / major reach)
- Per-team context annotates each pick with its rank/delta and adds a class-level summary (total value, average delta)
- Both prompts rewritten: model is instructed to **use FantasyCalc rank as authoritative ADP** rather than inventing its own. When a player isn't in FantasyCalc, the model is told to skip slot-value commentary entirely and focus on player profile and team fit.
- `value_vs_adp` is now **computed deterministically** (`pick_no - overallRank`) and overwritten before save. The frontend badge always matches the prompt context. `"0"` when no FantasyCalc data exists.
- No more magnitude cap — a #5 ranked player picked at slot 25 is legitimately a +20 steal, and the frontend renders that fine.

### Updated: `worker/src/cron.ts`
- `processDraftAnalysis` fetches the rookie value map alongside draft + picks (Promise.all). KV-cached, so 99% of ticks are free.
- Map passed through to both `generatePickAnalysis` and `generateTeamDraftGrade`.

### Bumped: `DRAFT_ANALYSIS_VERSION` v2 → v3

## Supersedes #70

PR #70 (the slot-judgment-banning prompt) is **obsoleted** by this one. With real ADP data, the model can talk about value and reaches accurately — banning the word was a workaround for missing data. Recommend closing #70 without merging.

## Post-merge steps

1. `cd worker && npx wrangler deploy`
2. Wipe v2 rows so the cron regenerates under v3:
   ```
   npx wrangler d1 execute dynastiest-league-db --remote --command="DELETE FROM draft_pick_analysis WHERE draft_id = '1326434695142981632'"
   ```
3. Also wipe team grades if the draft has finished:
   ```
   npx wrangler d1 execute dynastiest-league-db --remote --command="DELETE FROM team_draft_grade WHERE draft_id = '1326434695142981632'"
   ```
4. Watch `wrangler tail` for the first regenerated pick — should see a log line like `FantasyCalc loaded: 600 players, 12 picks` confirming the data fetch worked.

## Risk

- **External API dependency.** FantasyCalc could go down or change schemas. Handled: any failure returns an empty map and the cron continues with the no-ADP fallback path. The model gracefully drops slot-value commentary in that case.
- **League format hardcoded.** If your scoring is actually half-PPR or you go superflex, the values will be slightly off. Easy fix later — `fetchLeague()` already returns scoring settings.
- **Players FantasyCalc doesn't track.** Deep prospects in late rounds may not have a value. Handled — the prompt explicitly tells the model to skip slot-value commentary for those picks.

## Followups (not in this PR)

- Reading scoring/format from `fetchLeague()` instead of hardcoding (#59)
- Using FantasyCalc pick values for rookie picks in trade analysis
- "Regenerate analyses on version bump" mechanism so manual DELETE isn't needed for prompt iterations