### PR TITLE
Use rookie-only rank for slot-value delta, not overall dynasty rank

### DIFF
--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -64,9 +64,9 @@ function computeRosterShape(
 }
 
 /**
- * Bucket the slot-vs-rank delta into a qualitative label for the prompt.
- * Positive delta = picked LATER than expected = good value for drafter.
- * Negative delta = picked EARLIER than expected = reach.
+ * Bucket the slot-vs-rookieRank delta into a qualitative label for the prompt.
+ * Positive delta = picked LATER than the rookie's rank in the class = good value.
+ * Negative delta = picked EARLIER than rookie rank = reach.
  */
 function deltaLabel(delta: number): string {
   if (delta >= 8) return 'major value — fell well below consensus';
@@ -80,7 +80,10 @@ function deltaLabel(delta: number): string {
 
 interface PickContextResult {
   context: string;
-  /** Slot - overallRank. null when no FantasyCalc data is available. */
+  /**
+   * Slot - rookieRank. null when no rookieRank is available (player not in
+   * FantasyCalc, or not flagged as a rookie in Sleeper).
+   */
   computedDelta: number | null;
 }
 
@@ -123,25 +126,35 @@ function buildPickContext(
     .map((p) => p.metadata?.position ?? '?')
     .join(', ');
 
-  // FantasyCalc dynasty value (the authoritative ADP signal for rookies).
-  // The dynasty value already implicitly bakes in NFL Draft capital, landing
-  // spot, and athletic profile — exactly the signals the model is missing
-  // due to its training cutoff predating the actual NFL Draft.
+  // FantasyCalc dynasty rank, with rookie-only re-ranking applied.
+  //
+  // CRITICAL: We use rookieRank (rank among rookies in this class) for the
+  // slot-value delta — NOT overallRank (rank across all dynasty assets, vets
+  // included). Example: Travis Hunter might be overallRank #25 but rookieRank
+  // #1. In a rookie-only draft, picking him at slot 1 is exactly right, not
+  // a 24-slot reach. overallRank is shown as supplementary color but is not
+  // used for delta math.
   const fcValue = rookieValues.players[pick.player_id];
   let computedDelta: number | null = null;
   let valueLine = '';
-  if (fcValue) {
-    computedDelta = pick.pick_no - fcValue.overallRank;
+  if (fcValue && fcValue.rookieRank !== undefined) {
+    computedDelta = pick.pick_no - fcValue.rookieRank;
     const deltaSign = computedDelta > 0 ? '+' : '';
-    const posRankStr = fcValue.positionRank !== undefined
-      ? `, #${fcValue.positionRank} at ${position}`
+    const posRankStr = fcValue.rookiePositionRank !== undefined
+      ? ` (rookie ${position}${fcValue.rookiePositionRank} in this class)`
       : '';
     valueLine =
-      `Dynasty rank (FantasyCalc): #${fcValue.overallRank} overall${posRankStr} (value ${fcValue.value})\n` +
-      `Slot vs rank: picked at #${pick.pick_no}, ranked #${fcValue.overallRank} → delta ${deltaSign}${computedDelta} (${deltaLabel(computedDelta)})\n`;
+      `Rookie class rank: #${fcValue.rookieRank}${posRankStr}\n` +
+      `Slot vs rookie rank: picked at #${pick.pick_no}, ranked #${fcValue.rookieRank} among rookies → delta ${deltaSign}${computedDelta} (${deltaLabel(computedDelta)})\n` +
+      `(For dynasty context only — not used for slot evaluation: FantasyCalc overall rank #${fcValue.overallRank}, value ${fcValue.value}.)\n`;
+  } else if (fcValue) {
+    // Player has FantasyCalc data but no rookieRank — likely a non-rookie
+    // accidentally in the draft, or rookie flag is missing in Sleeper.
+    valueLine =
+      `Dynasty rank: FantasyCalc has this player but they aren't flagged as a rookie. Skip slot-value commentary; focus on profile and team fit.\n`;
   } else {
     valueLine =
-      `Dynasty rank: unavailable (player not found in FantasyCalc or data failed to load). Do not speculate about value; comment on player profile and team fit instead.\n`;
+      `Rookie rank: unavailable (player not found in FantasyCalc or data failed to load). Do not speculate about value; comment on player profile and team fit instead.\n`;
   }
 
   let context = `Pick #${pick.pick_no} (Round ${pick.round})\n`;
@@ -189,13 +202,13 @@ export async function generatePickAnalysis(
   const prompt = `You are Mike and Jim, two fantasy football analysts giving a quick take on a dynasty rookie draft pick.
 
 Context:
-- This is a ${draftRounds}-round, ${draftRounds * draftTeams}-pick dynasty rookie draft. Every player is an incoming NFL rookie.
-- The pick details below include the player's dynasty rank from FantasyCalc, which represents the consensus dynasty community valuation. Treat this as the authoritative source for whether the pick was made at a fair slot.
-- "Slot vs rank" tells you exactly whether the pick was good value, fair, or a reach. Use that as your starting point — do not invent your own ADP intuitions.
-- If a player has no FantasyCalc rank, do NOT speculate about value. Focus only on player profile and team fit.
+- This is a ${draftRounds}-round, ${draftRounds * draftTeams}-pick dynasty ROOKIE-ONLY draft. Every player taken is an incoming NFL rookie.
+- The pick details below include the player's "Rookie class rank" — their rank among the rookies in this class, derived from FantasyCalc dynasty values. THIS is the authoritative ADP for evaluating whether the pick was made at a fair slot. The slot vs rookie rank delta tells you exactly whether the pick was good value, fair, or a reach.
+- IGNORE the FantasyCalc overall rank for slot evaluation — that ranks across all dynasty assets including veterans, and would make every rookie look like a massive reach. It's shown only as supplementary dynasty context.
+- If a player has no rookie rank (rare deep prospect or data issue), do NOT speculate about value. Focus only on player profile and team fit.
 
 What to discuss:
-- Whether the pick was good value, fair, or a reach (per the delta)
+- Whether the pick was good value, fair, or a reach (per the slot-vs-rookie-rank delta)
 - Player profile and fit with the drafting team's roster shape
 - Positional dynasty appeal (elite WRs scarce, RBs age fast, QBs matter more in superflex)
 - Snark and entertainment
@@ -204,15 +217,15 @@ Pick details:
 ${context}
 
 Instructions:
-1. Letter grade (A+ through F) reflecting both player quality and slot value.
-2. value_vs_adp: short integer-string. Use the slot-vs-rank delta directly when available, "0" when no FantasyCalc data.
+1. Letter grade (A+ through F) reflecting both player quality and slot value (per the rookie rank delta).
+2. value_vs_adp: short integer-string. Use the slot-vs-rookie-rank delta directly when available, "0" when no rookie rank.
 3. 2–3 short, punchy Mike & Jim exchanges.
 4. One-sentence hot_take.`;
 
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
     max_tokens: 800,
-    system: 'You are Mike and Jim, dynasty fantasy football analysts. You evaluate rookie draft picks using FantasyCalc dynasty rankings as the authoritative consensus, supplemented by player profile and roster fit.',
+    system: 'You are Mike and Jim, dynasty fantasy football analysts. You evaluate rookie draft picks using rookie-class-only rankings as the authoritative consensus, supplemented by player profile and roster fit. You ignore overall dynasty rank for slot evaluation because rookie-only drafts are not measured against veterans.',
     tools: [
       {
         name: 'submit_pick_analysis',
@@ -232,7 +245,7 @@ Instructions:
   const analysis = toolUseBlock.input as Omit<DraftPickAnalysis, 'pick_id' | 'draft_id' | 'pick_no'>;
 
   // Always overwrite value_vs_adp with the computed delta (or "0" when we
-  // have no FantasyCalc data). The model's emitted value is unreliable; the
+  // have no rookie rank). The model's emitted value is unreliable; the
   // delta is deterministic and matches the prompt context exactly.
   const sanitizedValue = computedDelta !== null ? String(computedDelta) : '0';
 
@@ -304,7 +317,7 @@ function buildTeamGradeContext(
 
   let totalValue = 0;
   let totalSlotDelta = 0;
-  let picksWithValue = 0;
+  let picksWithDelta = 0;
 
   let context = `Team: ${teamName}\n`;
   if (shapeParts) {
@@ -324,24 +337,24 @@ function buildTeamGradeContext(
 
     const fcValue = rookieValues.players[pick.player_id];
     let valueSegment = '';
-    if (fcValue) {
-      const delta = pick.pick_no - fcValue.overallRank;
+    if (fcValue && fcValue.rookieRank !== undefined) {
+      const delta = pick.pick_no - fcValue.rookieRank;
       const deltaSign = delta > 0 ? '+' : '';
-      valueSegment = ` | Dynasty #${fcValue.overallRank} overall (delta ${deltaSign}${delta}: ${deltaLabel(delta)})`;
+      valueSegment = ` | Rookie #${fcValue.rookieRank} in class (delta ${deltaSign}${delta}: ${deltaLabel(delta)})`;
       totalValue += fcValue.value;
       totalSlotDelta += delta;
-      picksWithValue++;
+      picksWithDelta++;
     } else {
-      valueSegment = ' | Dynasty rank: unavailable';
+      valueSegment = ' | Rookie rank: unavailable';
     }
 
     context += `  Pick #${pick.pick_no} (Rd ${pick.round}): ${playerName} — ${position}, ${nflTeam}${age}${valueSegment}\n`;
   }
 
-  if (picksWithValue > 0) {
-    const avgDelta = totalSlotDelta / picksWithValue;
+  if (picksWithDelta > 0) {
+    const avgDelta = totalSlotDelta / picksWithDelta;
     const avgSign = avgDelta > 0 ? '+' : '';
-    context += `\nClass totals (FantasyCalc-rated picks only): total value ${totalValue}, average slot-vs-rank delta ${avgSign}${avgDelta.toFixed(1)}\n`;
+    context += `\nClass totals (rookie-ranked picks only): total FantasyCalc value ${totalValue}, average slot-vs-rookie-rank delta ${avgSign}${avgDelta.toFixed(1)}\n`;
   }
 
   return context;
@@ -374,28 +387,28 @@ export async function generateTeamDraftGrade(
   const prompt = `You are Mike and Jim grading one team's dynasty rookie draft class.
 
 Context:
-- This is a dynasty rookie draft. All picks below are incoming NFL rookies.
-- Each pick includes the player's FantasyCalc dynasty rank — the consensus dynasty community valuation. Use this as the authoritative source for whether picks were made at fair slots.
-- "Class totals" tells you the team's average slot-vs-rank delta. Positive average = team consistently got value. Negative average = team consistently reached.
+- This is a dynasty ROOKIE-ONLY draft. All picks below are incoming NFL rookies.
+- Each pick includes the player's rookie class rank — their rank among rookies in this class. Use this as the authoritative consensus for whether picks were made at fair slots.
+- "Class totals" tells you the team's average slot-vs-rookie-rank delta. Positive average = team consistently got value. Negative average = team consistently reached.
 
 Grade based on:
 - Total dynasty value accumulated (sum of FantasyCalc values)
 - How well the rookies fill positional needs in the existing roster
-- Whether the team got value at each slot or reached
+- Whether the team got value at each slot or reached (per the rookie-rank delta)
 - Positional dynasty appeal of the class (WRs and TEs age slowly; RBs are volatile)
 
 ${context}
 
 Instructions:
 1. Letter grade for the rookie class.
-2. Best pick + worst pick (by pick_no) with one-sentence reason each (cite the dynasty rank when relevant).
+2. Best pick + worst pick (by pick_no) with one-sentence reason each (cite the rookie rank when relevant).
 3. 2–3 sentence summary of the class.
 4. 2–3 exchanges between Mike and Jim about the team's strategy and execution.`;
 
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
     max_tokens: 1000,
-    system: 'You are Mike and Jim, dynasty fantasy football analysts. You grade rookie draft classes using FantasyCalc dynasty rankings as the authoritative consensus, total class value, slot-vs-rank deltas, and roster fit.',
+    system: 'You are Mike and Jim, dynasty fantasy football analysts. You grade rookie draft classes using rookie-class-only rankings as the authoritative consensus, total class value, slot-vs-rookie-rank deltas, and roster fit.',
     tools: [
       {
         name: 'submit_team_grade',

--- a/worker/src/rookieValues.ts
+++ b/worker/src/rookieValues.ts
@@ -10,19 +10,35 @@
  * from fetchLeague() — see issue #59 for the full integration spec.
  */
 
+import type { PlayerInfo } from './types';
+
 const FANTASYCALC_URL =
   'https://api.fantasycalc.com/values/current?isDynasty=true&numQbs=1&numTeams=10&ppr=1';
 
-const KV_KEY = 'fantasycalc_dynasty_v1';
+// Bumped from v1 → v2: RookieValue now carries rookieRank/rookiePositionRank,
+// computed from the player map. Old cached entries are missing those fields.
+const KV_KEY = 'fantasycalc_dynasty_v2';
 const TTL_SECONDS = 86400; // 24 hours — values shift slowly
 
 export interface RookieValue {
   /** FantasyCalc dynasty value (roughly 0–10000 scale) */
   value: number;
-  /** Overall rank across all dynasty assets (lower = more valuable) */
+  /** Overall rank across ALL dynasty assets, vets and rookies. Lower = better. */
   overallRank: number;
-  /** Rank within the player's position — omitted when not present in API response */
+  /** Rank within the player's position across all dynasty assets. */
   positionRank?: number;
+  /**
+   * Rank among ROOKIES ONLY in this class, by overallRank. 1 = best rookie.
+   * Undefined when the player isn't a rookie (years_exp !== 0) or when the
+   * player map wasn't available at fetch time. This is the authoritative
+   * rank for rookie-draft slot evaluation — overallRank is misleading
+   * because it counts veterans ahead of rookies.
+   */
+  rookieRank?: number;
+  /**
+   * Rank among rookies of the same position (e.g. "WR2 of this rookie class").
+   */
+  rookiePositionRank?: number;
 }
 
 export interface RookieValueMap {
@@ -59,10 +75,55 @@ function parsePickName(name: string): { season: string; round: number } | null {
 }
 
 /**
+ * Compute rookieRank and rookiePositionRank for each rookie player in the map.
+ * A "rookie" is any player whose Sleeper years_exp === 0.
+ *
+ * Mutates the provided map in-place (annotates each rookie's RookieValue).
+ */
+function annotateRookieRanks(
+  map: RookieValueMap,
+  playerMap: Record<string, PlayerInfo>,
+): void {
+  // Collect rookies along with their position, sorted by FantasyCalc overall rank
+  const rookies: Array<{ sleeperId: string; position: string; overallRank: number }> = [];
+
+  for (const [sleeperId, value] of Object.entries(map.players)) {
+    const info = playerMap[sleeperId];
+    if (!info || info.years_exp !== 0) continue;
+    rookies.push({
+      sleeperId,
+      position: info.position ?? 'UNK',
+      overallRank: value.overallRank,
+    });
+  }
+
+  rookies.sort((a, b) => a.overallRank - b.overallRank);
+
+  // Track running position-rank counter
+  const positionCounters: Record<string, number> = {};
+
+  rookies.forEach(({ sleeperId, position }, idx) => {
+    positionCounters[position] = (positionCounters[position] ?? 0) + 1;
+    map.players[sleeperId] = {
+      ...map.players[sleeperId],
+      rookieRank: idx + 1,
+      rookiePositionRank: positionCounters[position],
+    };
+  });
+}
+
+/**
  * Fetch (or return cached) the dynasty value map from FantasyCalc.
  * Returns an empty map on any error so callers can degrade gracefully.
+ *
+ * When playerMap is provided, each rookie's value is annotated with
+ * `rookieRank` (rank among all rookies in the class) and
+ * `rookiePositionRank` (rank among rookies of the same position).
  */
-export async function getRookieValueMap(kv: KVNamespace): Promise<RookieValueMap> {
+export async function getRookieValueMap(
+  kv: KVNamespace,
+  playerMap?: Record<string, PlayerInfo>,
+): Promise<RookieValueMap> {
   try {
     const cached = await kv.get(KV_KEY, 'json');
     if (cached) {
@@ -107,14 +168,21 @@ export async function getRookieValueMap(kv: KVNamespace): Promise<RookieValueMap
       }
     }
 
+    if (playerMap) {
+      annotateRookieRanks(map, playerMap);
+    }
+
     try {
       await kv.put(KV_KEY, JSON.stringify(map), { expirationTtl: TTL_SECONDS });
     } catch (err) {
       console.error('Failed to write rookie values to KV:', err);
     }
 
+    const rookieCount = Object.values(map.players).filter(
+      (v) => v.rookieRank !== undefined,
+    ).length;
     console.log(
-      `FantasyCalc loaded: ${Object.keys(map.players).length} players, ${Object.keys(map.picks).length} picks`,
+      `FantasyCalc loaded: ${Object.keys(map.players).length} players (${rookieCount} rookies ranked), ${Object.keys(map.picks).length} picks`,
     );
     return map;
   } catch (err) {


### PR DESCRIPTION
## Why

Per the live-draft thread: even with FantasyCalc wired in (#71), the model was still calling top picks reaches. Cause: I was using FantasyCalc's `overallRank` for the slot-vs-rank delta. `overallRank` is rank across **all dynasty assets** (vets included). The dynasty rookie WR1 might be `overallRank #25` because there are 24 better dynasty assets in the league — so picking him at slot 1 in a rookie-only draft looked like a 24-slot reach.

## What

Add a `rookieRank` annotation that ranks players among rookies only (filtered via `years_exp === 0` from Sleeper), and use that for the delta math instead. Picking the rookie WR1 at slot 1 is now `delta 0` — exactly fair.

### Changes

**`worker/src/rookieValues.ts`**
- New optional fields on `RookieValue`: `rookieRank`, `rookiePositionRank`
- New `annotateRookieRanks(map, playerMap)` helper — sorts FantasyCalc players who are rookies in Sleeper by `overallRank`, then assigns `rookieRank` (1-indexed) and `rookiePositionRank`
- `getRookieValueMap` accepts an optional `playerMap` and runs the annotation pass before caching
- KV cache key bumped `v1` → `v2` to invalidate old un-annotated cached entries

**`worker/src/draftAnalysis.ts`**
- `buildPickContext` and `buildTeamGradeContext` now use `rookieRank` for delta computation. `overallRank` is still printed in the prompt as supplementary dynasty context, but explicitly flagged as not for slot evaluation.
- Both prompts updated to refer to "Rookie class rank" and "slot-vs-rookie-rank delta" — language matches what's in the context block.
- System prompts updated to reinforce: rookie-class rankings, not overall dynasty rankings, drive slot evaluation in rookie-only drafts.
- Falls back to skipping slot-value commentary when a player has no `rookieRank` (rare deep prospect or non-rookie incorrectly in the draft).

**`worker/src/cron.ts`**
- Passes the player map into `getRookieValueMap` so rookie ranks can be computed at fetch time.
- Passes `draft.settings.rounds` and `draft.settings.teams` through to `generatePickAnalysis` for prompt accuracy ("4-round, 40-pick draft" rather than hardcoded).

## Caveats

- `years_exp === 0` is how we identify rookies. This works during the rookie-draft window (May–August) but Sleeper bumps `years_exp` to 1 once the new season's player data updates. For future seasons, the same logic will work as long as the draft happens before that update — typically true. If a draft were ever held after the year-flip, no players would be flagged as rookies and the system would fall back to no-delta behavior.
- League format still hardcoded to 10-team, 1QB, full PPR. Sourcing from `fetchLeague()` is tracked in #59.

## Post-merge steps

1. Close PR #70 without merging (it's stale and would regress this work).
2. `cd worker && npx wrangler deploy`
3. The KV cache key bumped to `v2`, so the next cron tick will re-fetch FantasyCalc and run the rookie-rank annotation. Watch `wrangler tail` for `FantasyCalc loaded: N players (M rookies ranked), K picks` confirming the annotation worked.
4. Wipe existing analyses so the cron regenerates under the new logic:
   ```
   npx wrangler d1 execute dynastiest-league-db --remote --command="DELETE FROM draft_pick_analysis WHERE draft_id = '1326434695142981632'"
   npx wrangler d1 execute dynastiest-league-db --remote --command="DELETE FROM team_draft_grade WHERE draft_id = '1326434695142981632'"
   ```

## Risk

Low. Schema unchanged. Frontend contract preserved. If the rookie-rank annotation fails for any reason (player not in Sleeper map, etc.), that pick falls back to no-delta behavior — same as the existing fallback for missing FantasyCalc data.