### PR TITLE
Fix team grade completeness: required fields, minItems, validation, larger token budget

### DIFF
--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -38,6 +38,8 @@ const PICK_ANALYSIS_SCHEMA = {
   required: ['grade', 'value_vs_adp', 'conversation', 'hot_take'],
 };
 
+const ALLOWED_CONVERSATION_SPEAKERS = new Set(['Mike', 'Jim']);
+
 function getTeamName(
   rosterId: number,
   rosters: SleeperRoster[],
@@ -92,7 +94,7 @@ function isConversationComplete(
   return conversation.every(
     (entry) =>
       typeof entry.speaker === 'string' &&
-      ['Mike', 'Jim'].includes(entry.speaker.trim()) &&
+      ALLOWED_CONVERSATION_SPEAKERS.has(entry.speaker.trim()) &&
       typeof entry.text === 'string' &&
       entry.text.trim().length > 0,
   );

--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -88,11 +88,11 @@ function deltaLabel(delta: number): string {
 function isConversationComplete(
   conversation: Array<{ speaker?: string; text?: string }> | undefined,
 ): boolean {
-  if (!conversation || conversation.length === 0) return false;
+  if (!conversation || conversation.length < 2) return false;
   return conversation.every(
     (entry) =>
       typeof entry.speaker === 'string' &&
-      entry.speaker.length > 0 &&
+      ['Mike', 'Jim'].includes(entry.speaker.trim()) &&
       typeof entry.text === 'string' &&
       entry.text.trim().length > 0,
   );
@@ -279,6 +279,11 @@ Instructions:
   if (!analysis.hot_take || analysis.hot_take.trim().length === 0) {
     throw new Error(
       `Pick analysis for #${pick.pick_no} returned an empty hot_take; will retry next tick`,
+    );
+  }
+  if (!analysis.grade || analysis.grade.trim().length === 0) {
+    throw new Error(
+      `Pick analysis for #${pick.pick_no} returned an empty grade; will retry next tick`,
     );
   }
 
@@ -485,12 +490,30 @@ Instructions (ALL fields are required — none may be omitted):
       `Team grade for roster ${rosterId} returned an empty summary; will retry next tick`,
     );
   }
-  if (!gradeOutput.best_pick || typeof gradeOutput.best_pick.pick_no !== 'number') {
+  if (
+    !gradeOutput.overall_grade ||
+    gradeOutput.overall_grade.trim().length === 0
+  ) {
+    throw new Error(
+      `Team grade for roster ${rosterId} returned an empty overall_grade; will retry next tick`,
+    );
+  }
+  if (
+    !gradeOutput.best_pick ||
+    !Number.isFinite(gradeOutput.best_pick.pick_no) ||
+    !gradeOutput.best_pick.reason ||
+    gradeOutput.best_pick.reason.trim().length === 0
+  ) {
     throw new Error(
       `Team grade for roster ${rosterId} returned an invalid best_pick; will retry next tick`,
     );
   }
-  if (!gradeOutput.worst_pick || typeof gradeOutput.worst_pick.pick_no !== 'number') {
+  if (
+    !gradeOutput.worst_pick ||
+    !Number.isFinite(gradeOutput.worst_pick.pick_no) ||
+    !gradeOutput.worst_pick.reason ||
+    gradeOutput.worst_pick.reason.trim().length === 0
+  ) {
     throw new Error(
       `Team grade for roster ${rosterId} returned an invalid worst_pick; will retry next tick`,
     );

--- a/worker/src/draftAnalysis.ts
+++ b/worker/src/draftAnalysis.ts
@@ -23,6 +23,7 @@ const PICK_ANALYSIS_SCHEMA = {
     value_vs_adp: { type: 'string' },
     conversation: {
       type: 'array',
+      minItems: 2,
       items: {
         type: 'object',
         properties: {
@@ -76,6 +77,25 @@ function deltaLabel(delta: number): string {
   if (delta >= -3) return 'slight reach';
   if (delta >= -7) return 'reach — taken meaningfully early';
   return 'major reach — taken well above consensus';
+}
+
+/**
+ * Validate that a conversation array is non-empty and every entry has both
+ * a speaker and non-blank text. Returns true if valid, false otherwise.
+ * Used as a guard before persisting so partial/truncated model output gets
+ * retried on the next cron tick instead of saved as broken data.
+ */
+function isConversationComplete(
+  conversation: Array<{ speaker?: string; text?: string }> | undefined,
+): boolean {
+  if (!conversation || conversation.length === 0) return false;
+  return conversation.every(
+    (entry) =>
+      typeof entry.speaker === 'string' &&
+      entry.speaker.length > 0 &&
+      typeof entry.text === 'string' &&
+      entry.text.trim().length > 0,
+  );
 }
 
 interface PickContextResult {
@@ -222,7 +242,7 @@ ${context}
 Instructions:
 1. Letter grade (A+ through F) reflecting both player quality and slot value (per the rookie rank delta).
 2. value_vs_adp: short integer-string. Use the slot-vs-rookie-rank delta directly when available, "0" when no rookie rank.
-3. 2–3 short, punchy Mike & Jim exchanges.
+3. 2–3 short, punchy Mike & Jim exchanges. The conversation MUST contain at least 2 entries with non-empty text.
 4. One-sentence hot_take.`;
 
   const response = await anthropic.messages.create({
@@ -246,6 +266,21 @@ Instructions:
   }
 
   const analysis = toolUseBlock.input as Omit<DraftPickAnalysis, 'pick_id' | 'draft_id' | 'pick_no'>;
+
+  // Validate completeness before returning. Empty conversations or missing
+  // hot_take indicate the model truncated or otherwise failed to populate
+  // the structured output. Throwing here lets the cron retry on the next
+  // tick instead of persisting a broken row.
+  if (!isConversationComplete(analysis.conversation)) {
+    throw new Error(
+      `Pick analysis for #${pick.pick_no} returned an empty or incomplete conversation; will retry next tick`,
+    );
+  }
+  if (!analysis.hot_take || analysis.hot_take.trim().length === 0) {
+    throw new Error(
+      `Pick analysis for #${pick.pick_no} returned an empty hot_take; will retry next tick`,
+    );
+  }
 
   // Always overwrite value_vs_adp with the computed delta (or "0" when we
   // have no rookie rank). The model's emitted value is unreliable; the
@@ -286,6 +321,7 @@ const TEAM_GRADE_SCHEMA = {
     summary: { type: 'string' },
     conversation: {
       type: 'array',
+      minItems: 2,
       items: {
         type: 'object',
         properties: {
@@ -296,7 +332,7 @@ const TEAM_GRADE_SCHEMA = {
       },
     },
   },
-  required: ['overall_grade', 'summary', 'conversation'],
+  required: ['overall_grade', 'best_pick', 'worst_pick', 'summary', 'conversation'],
 };
 
 function buildTeamGradeContext(
@@ -402,16 +438,21 @@ Grade based on:
 
 ${context}
 
-Instructions:
-1. Letter grade for the rookie class.
-2. Best pick + worst pick (by pick_no) with one-sentence reason each (cite the rookie rank when relevant).
-3. 2–3 sentence summary of the class.
-4. 2–3 exchanges between Mike and Jim about the team's strategy and execution.`;
+Instructions (ALL fields are required — none may be omitted):
+1. overall_grade: letter grade for the rookie class.
+2. best_pick: object with pick_no and one-sentence reason (cite rookie rank when relevant). REQUIRED — if every pick was strong, pick the strongest; if every pick was weak, pick the least weak.
+3. worst_pick: object with pick_no and one-sentence reason. REQUIRED — same logic in reverse.
+4. summary: 2–3 sentence summary of the class.
+5. conversation: 2–3 exchanges between Mike and Jim about the team's strategy and execution. MUST contain at least 2 entries with non-empty text.`;
 
+  // max_tokens raised from 1000 to 1500. The structured output (overall grade
+  // + two pick objects + summary + 2-3 conversation exchanges) was occasionally
+  // truncating under the 1000-token budget, producing empty conversation
+  // arrays. 1500 leaves comfortable headroom.
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
-    max_tokens: 1000,
-    system: 'You are Mike and Jim, dynasty fantasy football analysts. You grade rookie draft classes using rookie-class-only rankings as the authoritative consensus, total class value, slot-vs-rookie-rank deltas, and roster fit.',
+    max_tokens: 1500,
+    system: 'You are Mike and Jim, dynasty fantasy football analysts. You grade rookie draft classes using rookie-class-only rankings as the authoritative consensus, total class value, slot-vs-rookie-rank deltas, and roster fit. You always populate every field requested in the structured output.',
     tools: [
       {
         name: 'submit_team_grade',
@@ -429,11 +470,35 @@ Instructions:
   }
 
   const gradeOutput = toolUseBlock.input as Omit<TeamDraftGrade, 'draft_id' | 'roster_id'>;
+
+  // Validate completeness before returning. Even with the schema marking
+  // these fields required, the model can return empty strings or empty
+  // arrays under token pressure. Throwing here lets the cron retry on
+  // the next tick instead of persisting broken data.
+  if (!isConversationComplete(gradeOutput.conversation)) {
+    throw new Error(
+      `Team grade for roster ${rosterId} returned an empty or incomplete conversation; will retry next tick`,
+    );
+  }
+  if (!gradeOutput.summary || gradeOutput.summary.trim().length === 0) {
+    throw new Error(
+      `Team grade for roster ${rosterId} returned an empty summary; will retry next tick`,
+    );
+  }
+  if (!gradeOutput.best_pick || typeof gradeOutput.best_pick.pick_no !== 'number') {
+    throw new Error(
+      `Team grade for roster ${rosterId} returned an invalid best_pick; will retry next tick`,
+    );
+  }
+  if (!gradeOutput.worst_pick || typeof gradeOutput.worst_pick.pick_no !== 'number') {
+    throw new Error(
+      `Team grade for roster ${rosterId} returned an invalid worst_pick; will retry next tick`,
+    );
+  }
+
   return {
     ...gradeOutput,
     draft_id: draftId,
     roster_id: rosterId,
-    best_pick: gradeOutput.best_pick ?? null,
-    worst_pick: gradeOutput.worst_pick ?? null,
   };
 }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -21,7 +21,7 @@ crons = ["*/1 * * * *"]
 [vars]
 SLEEPER_LEAGUE_ID = "1326434695138787328"
 TRADE_ANALYSIS_VERSION = "v3"
-DRAFT_ANALYSIS_VERSION = "v5"
+DRAFT_ANALYSIS_VERSION = "v6"
 # LEAGUE_DRAFT_ID is optional. When unset, the cron auto-detects the active
 # (or most recent completed) draft via Sleeper's /league/{id}/drafts endpoint.
 # Set it explicitly only to override auto-detection for a specific draft.


### PR DESCRIPTION
## Why

Some team grades were rendering with missing best/worst sections and empty Mike-and-Jim conversation bubbles. Screenshot from production showed one team had full output, another had no best/worst and no conversation text — just speaker placeholders.

## Root causes (three, compounding)

1. **`best_pick` and `worst_pick` weren't required in `TEAM_GRADE_SCHEMA`'s `required[]` array.** The model could legally skip them, and apparently did for some teams.
2. **The conversation array had no `minItems` constraint.** An empty array passed schema validation, so when the model truncated mid-response it could return `conversation: []` and still satisfy the contract.
3. **`max_tokens: 1000` was tight** for a structured output that includes a grade, two pick objects, a multi-sentence summary, and 2-3 conversation exchanges. Under that budget, truncation produced the empty arrays.

## Changes

### `worker/src/draftAnalysis.ts`

- `TEAM_GRADE_SCHEMA.required` now includes `best_pick`, `worst_pick`, and `conversation`
- Both `TEAM_GRADE_SCHEMA.conversation` and `PICK_ANALYSIS_SCHEMA.conversation` get `minItems: 2`
- `generateTeamDraftGrade` `max_tokens` raised from `1000` → `1500`
- New `isConversationComplete()` helper validates non-empty entries (speaker present, text non-blank)
- Both `generatePickAnalysis` and `generateTeamDraftGrade` now throw if their output is incomplete (empty conversation, blank summary/hot_take, missing best/worst). The cron's existing try/catch will log the error and the row will be retried on the next tick instead of persisting broken data.
- Per-pick analysis got the same preemptive treatment even though the user only reported the team-grade variant — same structural risk, same one-line fix
- Prompts strengthened to call out that all fields are required and the conversation must have non-empty entries

### `worker/wrangler.toml`

- `DRAFT_ANALYSIS_VERSION`: `v5` → `v6`. With #75 merged, this triggers regen of all existing draft pick analyses and team grades under the fixed code.

## Failure-mode behavior change

Before: a model truncation silently saved a broken row. Frontend rendered placeholders.

After: a model truncation throws, the cron logs the error, and the row stays in its previous state (or remains absent) until the next tick re-generates it successfully. Self-healing.

If the model truncates on EVERY tick for a particular team (unlikely given the new token budget), the row will retry indefinitely. Worth monitoring `wrangler tail` for repeated "will retry next tick" lines on the same record.

## Post-merge

#73 auto-deploys this. #75's regen path takes care of refilling all rows under v6.

## Risk

Low. Schema additions are strictly stricter — any model output that satisfied the new schema also satisfied the old one. The validation throws are caught by the cron's existing error handling. Worst case: regen is slower than it was because some calls fail validation and retry — but with the bigger token budget, this should be rare.